### PR TITLE
Handle optional permissions argument not being supplied.

### DIFF
--- a/GetSasToken-Net/run.csx
+++ b/GetSasToken-Net/run.csx
@@ -26,12 +26,14 @@ public static async Task<HttpResponseMessage> Run(HttpRequestMessage req, TraceW
     }
 
     var permissions = SharedAccessBlobPermissions.Read; // default to read permissions
-    bool success = Enum.TryParse(data.permissions.ToString(), out permissions);
-
-    if (!success) {
-        return req.CreateResponse(HttpStatusCode.BadRequest, new {
-            error = "Invalid value for 'permissions'"
-        });
+    if (data.permissions != null) {
+        bool success = Enum.TryParse(data.permissions.ToString(), out permissions);
+    
+        if (!success) {
+            return req.CreateResponse(HttpStatusCode.BadRequest, new {
+                error = "Invalid value for 'permissions'"
+            });
+        }
     }
 
     var storageAccount = CloudStorageAccount.Parse(ConfigurationManager.AppSettings["AzureWebJobsStorage"]);


### PR DESCRIPTION
Fixing the unfiled issue where leaving out the optional permissions argument would result in a 500 Internal Server Error response with this error in the log:

Exception while executing function: Functions.GetSasToken-Net. Anonymously Hosted DynamicMethods Assembly: Cannot perform runtime binding on a null reference.